### PR TITLE
修正文案错误

### DIFF
--- a/zh/docs/08-working-with-the-browser.md
+++ b/zh/docs/08-working-with-the-browser.md
@@ -13,7 +13,7 @@ React提供了强大的抽象，让你在大多数应用场景中不再直接操
 
 React是很快的，因为它从不直接操作DOM。React在内存中维护一个快速响应的DOM描述。`render()`方法返回一个DOM的*描述*，React能够利用内存中的描述来快速地计算出差异，然后更新浏览器中的DOM。
 
-另外，React实现了一个完备的虚拟事件系统，尽管各个浏览器都有自己的怪异行为，React确保所有事件对象都确保符合W3C规范，并且持续冒泡，用一种高性能的方式跨浏览器（and everything bubbles consistently and in a performant way cross-browser）。你甚至可以在IE8中使用一些HTML5的事件！
+另外，React实现了一个完备的虚拟事件系统，尽管各个浏览器都有自己的怪异行为，React确保所有事件对象都符合W3C规范，并且持续冒泡，用一种高性能的方式跨浏览器（and everything bubbles consistently and in a performant way cross-browser）。你甚至可以在IE8中使用一些HTML5的事件！
 
 大多数时候你应该呆在React的“虚拟浏览器”世界里面，因为它性能更加好，并且容易思考。但是，有时你简单地需要调用底层的API，或许借助于第三方的类似于jQuery插件这种库。React为你提供了直接使用底层DOM API的途径。
 


### PR DESCRIPTION
在 `虚拟DOM` 一节中 `React确保所有事件对象都确保符合W3C规范` 应该描述为 `React确保所有事件对象都符合W3C规范`