### PR TITLE
修改“可用的命令（Available commands）”中“$splice”的翻译，使得译文更容易理解

### DIFF
--- a/zh/docs/10.6-update.md
+++ b/zh/docs/10.6-update.md
@@ -59,7 +59,7 @@ The `$`-prefixed keys are called *commands*. The data structure they are "mutati
 
   * `{$push: array}` 利用`push()`把目标上所有的元素放进`数组`（`push()` all the items in `array` on the target.）。
   * `{$unshift: array}` 利用`unshift()`把目标上所有的元素放进`数组`（`unshift()` all the items in `array` on the target.）。
-  * `{$splice: array of arrays}` 对于`array`中的每一个元素，用元素提供的参数在目标上调用`splice()`（for each item in `arrays` call `splice()` on the target with the parameters provided by the item.）。
+  * `{$splice: array of arrays}` 依次使用`arrays`中的元素（`array`）作为参数，在目标对象上调用`splice`方法（for each item in `arrays` call `splice()` on the target with the parameters provided by the item.）。
   * `{$set: any}` 整体替换目标（replace the target entirely.）。
   * `{$merge: object}` 合并目标和`object`的键。
   * `{$apply: function}` 传入当前的值到函数，然后用新返回的值更新它（passes in the current value to the function and updates it with the new returned value.）。


### PR DESCRIPTION
原来的翻译是直译，比较生硬并且不容易理解