### PR TITLE
zh Gemfile source

### DIFF
--- a/zh/Gemfile
+++ b/zh/Gemfile
@@ -1,4 +1,4 @@
-source 'http://ruby.taobao.org'
+source 'https://ruby.taobao.org'
 
 gem 'rake'
 


### PR DESCRIPTION
`Could not fetch specs from http://ruby.taobao.org/`

> 我们已经停止基于 HTTP 协议的镜像服务, 请在配置中使用 HTTPS 协议代替

